### PR TITLE
Updating devon4j and devon4ng URLs

### DIFF
--- a/code.html
+++ b/code.html
@@ -140,10 +140,10 @@
                             <a href="https://devonfw.com" class="text-white">devonfw</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4j" class="text-white">devon4J</a>
+                            <a href="https://devon4j.github.io/" class="text-white">devon4J</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4ng" class="text-white">devon4ng</a>
+                            <a href="https://devon4ng.github.io/" class="text-white">devon4ng</a>
                         </span>
                     </p>
                 </div>

--- a/getstarted.html
+++ b/getstarted.html
@@ -209,10 +209,10 @@
                             <a href="https://devonfw.com" class="text-white">devonfw</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4j" class="text-white">devon4J</a>
+                            <a href="https://devon4j.github.io/" class="text-white">devon4J</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4ng" class="text-white">devon4ng</a>
+                            <a href="https://devon4ng.github.io/" class="text-white">devon4ng</a>
                         </span>
                     </p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -196,10 +196,10 @@
                             <a href="https://devonfw.com" class="text-white">devonfw</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4j" class="text-white">devon4J</a>
+                            <a href="https://devon4j.github.io/" class="text-white">devon4J</a>
                         </span> |
                         <span>
-                            <a href="https://devonfw.com/devon4ng" class="text-white">devon4ng</a>
+                            <a href="https://devon4ng.github.io/" class="text-white">devon4ng</a>
                         </span>
                     </p>
                 </div>


### PR DESCRIPTION
Updating references to `devon4j` and `devon4ng`. The URLs were pointing to the old webpages..